### PR TITLE
maint: version bump for openwakeword

### DIFF
--- a/openwakeword/CHANGELOG.md
+++ b/openwakeword/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.8.2
+
+- Handle wake word aliases
+- Add executable
+- correct argument descriptions
+
 ## 1.8.1
 
 - Remove batching from wake word processing since not all models support it

--- a/openwakeword/Dockerfile
+++ b/openwakeword/Dockerfile
@@ -4,7 +4,7 @@ ARG TARGETVARIANT
 
 # Install openWakeWord
 WORKDIR /usr/src
-ARG OPENWAKEWORD_LIB_VERSION='1.8.1'
+ARG OPENWAKEWORD_LIB_VERSION='1.8.2'
 
 RUN \
     apt-get update \

--- a/openwakeword/Makefile
+++ b/openwakeword/Makefile
@@ -1,6 +1,6 @@
 .PHONY: local run update
 
-VERSION := 1.8.1
+VERSION := 1.8.2
 TAG := rhasspy/wyoming-openwakeword
 PLATFORMS := linux/amd64,linux/arm64,linux/arm/v7
 MODEL := "ok_nabu"


### PR DESCRIPTION
Just a version bump to use openwakeword 1.8.2

This seems to be working fine with the older version of the satellite [synesthesiam repo](https://github.com/synesthesiam/homeassistant-satellite)

I can't get the newer version to work for the life of me, so haven't tested it there yet.