### PR TITLE
Fix whisper version

### DIFF
--- a/whisper/Dockerfile
+++ b/whisper/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:bullseye-slim
 
 # Install Whisper
 WORKDIR /usr/src
-ARG WYOMING_WHISPER_VERSION='2.2.0'
+ARG WYOMING_WHISPER_VERSION='2.4.0'
 
 RUN \
     apt-get update \

--- a/whisper/Makefile
+++ b/whisper/Makefile
@@ -10,13 +10,13 @@ HOST := 0.0.0.0
 PORT := 10300
 
 all:
-	docker buildx build . --platform "$(PLATFORMS)" --tag "$(TAG):$(VERSION)" --push
+	docker buildx build . --platform "$(PLATFORMS)" --tag "$(TAG):$(VERSION)" --build-arg WYOMING_WHISPER_VERSION=$(VERSION) --push
 
 update:
-	docker buildx build . --platform "$(PLATFORMS)" --tag "$(TAG):latest" --push
+	docker buildx build . --platform "$(PLATFORMS)" --tag "$(TAG):latest" --build-arg WYOMING_WHISPER_VERSION=$(VERSION) --push
 
 local:
-	docker build . -t "$(TAG):$(VERSION)" --build-arg TARGETARCH=amd64
+	docker build . -t "$(TAG):$(VERSION)" --build-arg TARGETARCH=amd64 --build-arg WYOMING_WHISPER_VERSION=$(VERSION)
 
 run:
 	mkdir -p "$(DATA_DIR)"


### PR DESCRIPTION
The version currently released as "2.4.0" is actually faster-whisper 2.2.0 because the version number wasn't being applied correctly in the makefile. This fixes that. 