### PR TITLE
Add stt-fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Docker-only builds for Home Assistant add-ons that use the [Wyoming protocol](ht
 * [microWakeWord](https://hub.docker.com/r/rhasspy/wyoming-microwakeword) ([Add-on](https://github.com/rhasspy/hassio-addons/tree/master/microwakeword/README.md))
 * [rhasspy-speech](https://hub.docker.com/r/rhasspy/wyoming-rhasspy-speech) ([Add-on](https://github.com/rhasspy/hassio-addons/tree/master/rhasspy-speech/README.md))
 * [speech-to-phrase](https://hub.docker.com/r/rhasspy/wyoming-speech-to-phrase) ([Add-on](https://github.com/home-assistant/addons/blob/master/speech_to_phrase/README.md))
+* [stt-fallback](https://hub.docker.com/r/rhasspy/wyoming-stt-fallback) ([Add-on](https://github.com/rhasspy/hassio-addons/blob/master/stt-fallback/README.md))
 
 
 ## Run Whisper

--- a/stt-fallback/CHANGELOG.md
+++ b/stt-fallback/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release

--- a/stt-fallback/Dockerfile
+++ b/stt-fallback/Dockerfile
@@ -1,0 +1,44 @@
+FROM debian:bookworm-slim
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+# Install stt-fallback
+WORKDIR /usr/src
+ENV STT_FALLBACK_VERSION=1.0.0
+ENV COMMIT=f3ed8114eddc11382552e1c3a4329c0b7c823ce4
+
+RUN \
+    apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3 \
+        python3-pip \
+        python3-dev \
+        python3-venv \
+#        libopenblas0 \
+#        libencode-perl \
+        curl \
+#        build-essential \
+        libarchive-tools \
+    \
+    && mkdir ./tools \
+    && curl --location --output - \
+        "https://github.com/rhasspy/hassio-addons/archive/${COMMIT}.zip" | \
+        bsdtar -C ./tools -xf - \
+    && mv ./tools/hassio-addons-${COMMIT}/stt-fallback/src ./tools/stt-fallback \
+    && mv ./tools/hassio-addons-${COMMIT}/stt-fallback/requirements.txt ./tools/stt-fallback \
+    && rm -rf ./tools/hassio-addons-${COMMIT} \
+    && python3 -m venv .venv \
+    && .venv/bin/pip3 install --no-cache-dir \
+        -r ./tools/stt-fallback/requirements.txt \
+    && apt-get remove --yes build-essential libarchive-tools curl \
+    && apt-get autoremove --yes \
+    && apt-get clean \
+    && apt-get purge \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /
+COPY run.sh ./
+
+EXPOSE 10300
+
+ENTRYPOINT ["bash", "/run.sh"]

--- a/stt-fallback/Dockerfile
+++ b/stt-fallback/Dockerfile
@@ -14,10 +14,7 @@ RUN \
         python3-pip \
         python3-dev \
         python3-venv \
-#        libopenblas0 \
-#        libencode-perl \
         curl \
-#        build-essential \
         libarchive-tools \
     \
     && mkdir ./tools \

--- a/stt-fallback/Dockerfile
+++ b/stt-fallback/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 ARG TARGETARCH
 ARG TARGETVARIANT
 

--- a/stt-fallback/Makefile
+++ b/stt-fallback/Makefile
@@ -1,0 +1,19 @@
+.PHONY: local run update
+
+VERSION := 1.0.0
+TAG := rhasspy/wyoming-stt-fallback
+PLATFORMS := linux/amd64,linux/arm64
+HOST := 0.0.0.0
+PORT := 10300
+
+all:
+	docker buildx build . --platform "$(PLATFORMS)" --tag "$(TAG):$(VERSION)" --push
+
+update:
+	docker buildx build . --platform "$(PLATFORMS)" --tag "$(TAG):latest" --push
+
+local:
+	docker build . -t "$(TAG):$(VERSION)" --build-arg TARGETARCH=amd64
+
+run:
+	docker run -it -p '$(PORT):$(PORT)' "$(TAG):$(VERSION)" --uri 'tcp://$(HOST):$(PORT)' --debug

--- a/stt-fallback/run.sh
+++ b/stt-fallback/run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+cd /usr/src || exit 1
+.venv/bin/python3 /usr/src/tools/stt-fallback/stt_fallback.py \
+    --uri 'tcp://0.0.0.0:10300' "$@"


### PR DESCRIPTION
Add a stand-alone docker image for stt-fallback. This allows you to profit from the execution speed of speech-to-phrase while keeping the flexibility of an open text-to-speech system, such as whisper or a cloud service.

Use it with a docker-compose.yaml like this
```
name: wyoming-stt-fallback
services:
    wyoming-stt-fallback:
        container_name: stt-fallback
        ports:
            - 10500:10300
        volumes:
            - /etc/timezone:/etc/timezone:ro
            - /etc/localtime:/etc/localtime:ro
        image: rhasspy/wyoming-stt-fallback
        command: --hass-http-uri 'http://host.docker.internal:8123/api' --hass-token '<your_token_here>' stt.speech_to_phrase stt.faster_whisper
        extra_hosts:
        - "host.docker.internal:host-gateway"
        restart: unless-stopped
```
