### PR TITLE
Update to Debian Trixie

### DIFF
--- a/microwakeword/Dockerfile
+++ b/microwakeword/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 ARG TARGETARCH
 ARG TARGETVARIANT
 

--- a/openwakeword/Dockerfile
+++ b/openwakeword/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 ARG TARGETARCH
 ARG TARGETVARIANT
 

--- a/piper/Dockerfile
+++ b/piper/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 ARG TARGETARCH
 ARG TARGETVARIANT
 

--- a/porcupine1/Dockerfile
+++ b/porcupine1/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 ARG TARGETARCH
 ARG TARGETVARIANT
 

--- a/rhasspy-speech/Dockerfile
+++ b/rhasspy-speech/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 ARG TARGETARCH
 ARG TARGETVARIANT
 

--- a/snowboy/Dockerfile
+++ b/snowboy/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 ARG TARGETARCH
 ARG TARGETVARIANT
 

--- a/speech-to-phrase/Dockerfile
+++ b/speech-to-phrase/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 ARG TARGETARCH
 ARG TARGETVARIANT
 

--- a/vosk/Dockerfile
+++ b/vosk/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 ARG TARGETARCH
 ARG TARGETVARIANT
 

--- a/whisper-cpp/Dockerfile
+++ b/whisper-cpp/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 ARG TARGETARCH
 ARG TARGETVARIANT
 

--- a/whisper/Dockerfile
+++ b/whisper/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 # Install Whisper
 WORKDIR /usr/src


### PR DESCRIPTION
Debian Bookworm is losing full Debian support on July 11, 2026, see https://www.debian.org/releases/bookworm/

This updates all containers images to Debian Trixie.